### PR TITLE
Fix walk of habitat tree

### DIFF
--- a/grails-app/conf/ApplicationResources.groovy
+++ b/grails-app/conf/ApplicationResources.groovy
@@ -45,14 +45,8 @@ modules = {
     }
 
     'map' {
-        dependsOn 'google-maps-api'
-
         resource url: '/js/keydragzoom.js'
         resource url: '/js/wms.js'
-    }
-
-    'google-maps-api' {
-        resource  url: 'https://maps.google.com/maps/api/js?sensor=false', attrs: [type: "js"], disposition: 'head'
     }
 
     charts {

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -37,7 +37,7 @@ grails.project.dependency.resolution = {
 
         compile ":ajaxanywhere:1.0-SNAPSHOT"
 
-        runtime (":ala-bootstrap2:2.3") {
+        runtime (":ala-bootstrap2:2.4.5") {
             exclude "jquery"
         }
         if (Environment.current == Environment.PRODUCTION) {
@@ -46,7 +46,7 @@ grails.project.dependency.resolution = {
             compile ":cache-headers:1.1.7"
             runtime ":yui-minify-resources:0.1.5"
         }
-        runtime ':ala-auth:1.0'
+        runtime ':ala-auth:1.3.4'
 
     }
 }

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -36,10 +36,8 @@ grails.project.dependency.resolution = {
         build ":rest-client-builder:2.0.3"
 
         compile ":ajaxanywhere:1.0-SNAPSHOT"
+        runtime (":ala-bootstrap2:2.4.5")
 
-        runtime (":ala-bootstrap2:2.4.5") {
-            exclude "jquery"
-        }
         if (Environment.current == Environment.PRODUCTION) {
             runtime ":zipped-resources:1.0.1"
             runtime ":cached-resources:1.1"

--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -185,3 +185,6 @@ layers.queryContextDisplayName=''
 layers.queryContextFid=''
 layers.queryContextBieContext=''
 layers.queryContextOrder=''
+
+// do a redirect for downloads - to make use of the biocache downloads plugin for offline downloads
+redirectDownloads = false

--- a/grails-app/controllers/au/org/ala/regions/HabitatController.groovy
+++ b/grails-app/controllers/au/org/ala/regions/HabitatController.groovy
@@ -22,8 +22,13 @@ class HabitatController {
         if(node.containsKey(habitatID)){
             nodeToReturn = node.get(habitatID)
         } else {
-            if(node.children){
-                nodeToReturn = findNode(node.children, habitatID)
+            for (Map.Entry me : node.entrySet()) {
+                if (me.getValue() instanceof Map) {
+                    if(me.getValue().containsKey("children")) {
+                        nodeToReturn = findNode(me.getValue().children, habitatID)
+                        if (nodeToReturn != null) break;
+                    }
+                }
             }
         }
         nodeToReturn

--- a/grails-app/controllers/au/org/ala/regions/HabitatController.groovy
+++ b/grails-app/controllers/au/org/ala/regions/HabitatController.groovy
@@ -16,6 +16,27 @@ class HabitatController {
         [config : metadataService.getHabitatConfig()]
     }
 
+    def findNode(node, habitatID){
+        println("finding habitat ID: " + habitatID)
+        def nodeToReturn = null
+        if(node.containsKey(habitatID)){
+            nodeToReturn = node.get(habitatID)
+        } else {
+            if(node.children){
+                nodeToReturn = findNode(node.children, habitatID)
+            }
+        }
+        nodeToReturn
+    }
+
+    def flattenNode(node){
+        def nodes = [node.name]
+        node.children.each { key, value ->
+            nodes << value.name
+        }
+        nodes
+    }
+
     /**
      * Takes a habitat ID and constructs a biocache query for one or more habitats.
      *
@@ -24,16 +45,18 @@ class HabitatController {
     def viewRecords(){
 
         def habitatID = params.habitatID
+        def config = metadataService.getHabitatConfig()
 
-        def habitatsUrl = new URL(grailsApplication.config.bieService.baseURL +  "/habitat/ids/" + habitatID)
-        def js = new JsonSlurper()
-        def habitats = js.parseText(habitatsUrl.text)
+        //find the node
+        def node = findNode(config.tree, habitatID)
 
+        def flattenValues = flattenNode(node)
+//
         def fqParam = "("
         def title = ""
 
         //retrieve child IDs and construct a query
-        habitats.searchResults.eachWithIndex { habitat, idx ->
+        flattenValues.eachWithIndex { habitat, idx ->
             if(idx > 0){
                 fqParam = fqParam + " OR "
                 title = title + ", "
@@ -54,6 +77,10 @@ class HabitatController {
             response.success = { resp, json ->
                 def qid = json.keySet().first()
                 redirect(url: grailsApplication.config.biocache.baseURL  + "/occurrences/search?q=qid:" + qid)
+            }
+
+            response.failure = { resp, reader ->
+                 [response:resp, reader:reader]
             }
         }
     }

--- a/grails-app/views/habitat/index.gsp
+++ b/grails-app/views/habitat/index.gsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <meta name="layout" content="${grailsApplication.config.layout.skin?:'main'}"/>
+    <meta name="layout" content="${grailsApplication.config.skin.layout?:'main'}"/>
     <title>Habitats | ${grailsApplication.config.orgNameLong}</title>
     <r:require modules="regions,leaflet"/>
     <style type="text/css">

--- a/grails-app/views/regions/region.gsp
+++ b/grails-app/views/regions/region.gsp
@@ -123,12 +123,16 @@
                     </aa:zone>
                 </table>
                 <div class="text-center" id="exploreButtons">
-                    <a href="" id="viewRecords" class="btn"><i class="fa fa-share-square-o"></i> View Records</a>
-
-                    <a href="${g.createLink(controller: 'region', action: 'showDownloadDialog')}"
-                       aa-refresh-zones="dialogZone" aa-js-before="regionWidget.showDownloadDialog();" class="btn">
-                        <i class="fa fa-download"></i> Download Records
-                    </a>
+                    <a href="" id="viewRecords" class="btn"><i class="fa fa-share-square-o"></i> View records</a>
+                    <g:if test="true">
+                        <a href="" id="downloadRecords" class="btn"><i class="fa fa-download"></i> Download records</a>
+                    </g:if>
+                    <g:else>
+                        <a href="${g.createLink(controller: 'region', action: 'showDownloadDialog')}"
+                           aa-refresh-zones="dialogZone" aa-js-before="regionWidget.showDownloadDialog();" class="btn">
+                            <i class="fa fa-download"></i> Download Records
+                        </a>
+                    </g:else>
                 </div>
             </div>
             <div class="tab-pane" id="taxonomyTabContent">
@@ -305,7 +309,8 @@
                 spatialServiceUrl: "${grailsApplication.config.layersService.baseURL}/",
             },
             username: '${rg.loggedInUsername()}',
-            q: '${region.q}'
+            q: '${region.q}',
+            redirectDownloads: ${grailsApplication.config.redirectDownloads.toBoolean()}
             <g:if test="${enableQueryContext}">
                 ,qc:"${URLEncoder.encode(grailsApplication.config.biocache.queryContext, "UTF-8")}"
             </g:if>

--- a/grails-app/views/regions/region.gsp
+++ b/grails-app/views/regions/region.gsp
@@ -1,8 +1,14 @@
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <meta name="layout" content="${grailsApplication.config.layout.skin?:'main'}"/>
+    <meta name="layout" content="${grailsApplication.config.skin.layout?:'main'}"/>
     <title>${region.name} | ${grailsApplication.config.orgNameLong}</title>
+    <g:if test="${grailsApplication.config.google.apikey}">
+        <script async defer src="https://maps.googleapis.com/maps/api/js?key=${grailsApplication.config.google.apikey}" type="text/javascript"></script>
+    </g:if>
+    <g:else>
+        <script type="text/javascript" src="https://www.google.com/jsapi"></script>
+    </g:else>
     <r:require modules="region, bootstrapSwitch"/>
 </head>
 <body class="nav-locations regions">

--- a/grails-app/views/regions/regions.gsp
+++ b/grails-app/views/regions/regions.gsp
@@ -3,9 +3,15 @@
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <meta name="layout" content="${grailsApplication.config.layout.skin?:'main'}"/>
+    <meta name="layout" content="${grailsApplication.config.skin.layout?:'main'}"/>
     <title>Regions | ${grailsApplication.config.orgNameLong}</title>
     <script src="${g.createLink(controller: 'data',action: 'regionsMetadataJavascript')}"></script>
+    <g:if test="${grailsApplication.config.google.apikey}">
+        <script async defer src="https://maps.googleapis.com/maps/api/js?key=${grailsApplication.config.google.apikey}" type="text/javascript"></script>
+    </g:if>
+    <g:else>
+        <script type="text/javascript" src="https://www.google.com/jsapi"></script>
+    </g:else>
     <r:require modules="regions"/>
 
 </head>

--- a/web-app/js/region.js
+++ b/web-app/js/region.js
@@ -122,6 +122,8 @@ var RegionWidget = function (config) {
 
     var urls = {};
 
+    var redirectDownloads = false;
+
     /**
      * Constructor
      * @param config
@@ -141,6 +143,8 @@ var RegionWidget = function (config) {
         state.q = config.q;
         state.showHubData = config.showHubData || false;
         state.hubFilter = config.hubFilter || '';
+
+        state.redirectDownloads = config.redirectDownloads;
 
         // Check previous existing state
         updateState($.bbq.getState());
@@ -167,6 +171,10 @@ var RegionWidget = function (config) {
 
         initializeViewRecordsButton();
 
+        if(state.redirectDownloads) {
+            initializeDownloadRecordsButton();
+        }
+
         // Initialize `nload records dialog
         $('#downloadRecordsModal').modal({show: false});
     };
@@ -185,7 +193,7 @@ var RegionWidget = function (config) {
     };
 
     /**
-     *
+     * Add a click event to view records button.
      */
     var initializeViewRecordsButton = function() {
         $('#viewRecords').click(function(event) {
@@ -206,7 +214,7 @@ var RegionWidget = function (config) {
 
             if(state.qc){
                 //when using qc, biocache search fails. AtlasOfLivingAustralia/biocache-hubs#176
-                url += '&fq=' +state.qc
+                url += '&fq=' + state.qc
             }
 
             if(state.showHubData){
@@ -214,6 +222,46 @@ var RegionWidget = function (config) {
             }
 
             document.location.href = url;
+        });
+    };
+
+    /**
+     * Add a click event to download button.
+     */
+    var initializeDownloadRecordsButton = function() {
+        $('#downloadRecords').click(function(event) {
+            event.preventDefault();
+
+            console.log("state.q = " + state.q);
+            console.log("state.q (decoded) = " + decodeURI(state.q));
+            console.log("state.q (decoded decoded) = " + decodeURI(decodeURI(state.q)));
+
+            var baseUrl = urls.biocacheWebappUrl + "/download?searchParams=";
+            var targetUri = "&targetUri=" + encodeURI(urls.regionsApp);
+
+            // check what group is active
+            var url = "%3Fq%3D" + encodeURI(state.q) + encodeURI('&fq=rank:(species OR subspecies)');
+            if (!regionWidget.isDefaultFromYear() || !regionWidget.isDefaultToYear()) {
+                url += encodeURI('&fq=' + region.buildTimeFacet());
+            }
+            if (state.group != 'ALL_SPECIES') {
+                if (state.subgroup) {
+                    url += encodeURI('&fq=species_subgroup:"' + state.subgroup + '"');
+                } else {
+                    url += encodeURI('&fq=species_group:"' + state.group + '"');
+                }
+            }
+
+            if(state.qc){
+                //when using qc, biocache search fails. AtlasOfLivingAustralia/biocache-hubs#176
+                url += encodeURI('&fq=') + state.qc
+            }
+
+            if(state.showHubData){
+                url += encodeURI('&fq=') + state.hubFilter
+            }
+
+            document.location.href = baseUrl + url + targetUri ;
         });
     };
 


### PR DESCRIPTION
The original code was always returning null, as it failed to walk the tree. It is possible we have an incorrectly structured tree, though: the habitats.json we have for scotland-regions.nbnatlas.org looks like
"tree": {
    "A": {
      "children": {
        "A1": {
          "guid": "A1",
          "name": "Littoral rock and other hard substrata",
          "pid": "1000:8",
          "rasterID": "8"
        },
        "A2": {
          "children": {
            "A2.5": {
              "guid": "A2.5",
              "name": "Coastal saltmarshes and saline reedbeds",
              "pid": "1000:29",
              "rasterID": "29"
            }
          }, [etc]