### PR TITLE
Fix number format for languages with country variant like de_AT

### DIFF
--- a/grails-app/assets/javascripts/region_page.js
+++ b/grails-app/assets/javascripts/region_page.js
@@ -167,10 +167,11 @@ var region = {
      * @param count the number
      */
     format: function (count) {
+        // Convert de_AT to de-AT, etc
         if (count >= 1000000) {
-            return $.i18n.prop("count.million",  Number(count/1000000).toLocaleString(REGION_CONFIG.locale, { minimumFractionDigits: 0, maximumSignificantDigits: 2,  }));
+            return $.i18n.prop("count.million",  Number(count/1000000).toLocaleString(REGION_CONFIG.locale.replace("_", "-"), { minimumFractionDigits: 0, maximumSignificantDigits: 2,  }));
         }
-        return Number(count).toLocaleString(REGION_CONFIG.locale);
+        return Number(count).toLocaleString(REGION_CONFIG.locale.replace("_", "-"));
     },
 };
 


### PR DESCRIPTION
Some sample code of the number formatting that is falling:
https://jsfiddle.net/vruizjurado/y1tzxv7f/8/

More details in this conversation:
https://atlaslivingaustralia.slack.com/archives/CCTFGEU1G/p1596443788230200?thread_ts=1595837202.217900&cid=CCTFGEU1G