### PR TITLE
Remove redundant and faulty resourceName in alerts url call

### DIFF
--- a/grails-app/services/au/org/ala/regions/MetadataService.groovy
+++ b/grails-app/services/au/org/ala/regions/MetadataService.groovy
@@ -230,7 +230,7 @@ class MetadataService {
                     uiQuery         : URIUtil.encodeWithinQuery("/occurrences/search?${searchTerms}"),
                     queryDisplayName: URIUtil.encodeWithinQuery(region.name),
                     baseUrlForWS    : URIUtil.encodeWithinQuery("${BIOCACHE_SERVICE_URL}"),
-                    baseUrlForUI    : URIUtil.encodeWithinQuery("${BIOCACHE_URL}&resourceName=Atlas"),
+                    baseUrlForUI    : URIUtil.encodeWithinQuery("${BIOCACHE_URL}"),
                     resourceName    : URIUtil.encodeWithinQuery( grailsApplication.config.getProperty("alertsResourceName") ) 
             ]
 


### PR DESCRIPTION
The current code produce alerts with records URLs in regions alerts like:

https://registros.gbif.es&resourcename=atlas/occurrences/afd5c6e4-60cd-4df0-916f-19bd3ab0474e
instead of:
https://registros.gbif.es/occurrences/afd5c6e4-60cd-4df0-916f-19bd3ab0474e

Looking in the code, `&resourceName=Atlas` is added to the biocache Url but it is also added as query param below. 

Tested in our production regions service.