### PR TITLE
Correctly encoded region names in alert call

### DIFF
--- a/grails-app/services/au/org/ala/regions/MetadataService.groovy
+++ b/grails-app/services/au/org/ala/regions/MetadataService.groovy
@@ -224,8 +224,8 @@ class MetadataService {
      */
     String buildAlertsUrl(Map region) {
         URLDecoder.decode(new URIBuilder("${ALERTS_URL}/webservice/createBiocacheNewRecordsAlert").with {
-            String searchTerms = paramsToString(buildCommonDownloadRecordsParams(region.fid, region.type, region.name, region.pid))
-
+            String searchTerms = paramsToString(buildCommonDownloadRecordsParams(region.fid, region.type,
+                    URIUtil.encodeWithinQuery(region.name), region.pid))
             query = [
                     webserviceQuery : URIUtil.encodeWithinQuery("/occurrences/search?${searchTerms}"),
                     uiQuery         : URIUtil.encodeWithinQuery("/occurrences/search?${searchTerms}"),


### PR DESCRIPTION
Fix for #84.

I've tested in my dev environment and our production spatial service, so I attach my dev config so it's more easy to test it.

[regions-config.properties.txt](https://github.com/AtlasOfLivingAustralia/regions/files/5666249/regions-config.properties.txt)

