### PR TITLE
Optional accordion tooltips with layer notes

### DIFF
--- a/grails-app/assets/stylesheets/regions.css
+++ b/grails-app/assets/stylesheets/regions.css
@@ -547,3 +547,14 @@ div #maploading > div > i {
 .leaflet-container {
     cursor: pointer !important;
 }
+
+.ui-tooltip {
+    /* For some reason this had a bigger opacity, almost invisible */
+    opacity: .9;
+}
+
+.layer-info {
+    margin-top: 3px;
+    color: gray;
+    float:right;
+}

--- a/grails-app/conf/application.groovy
+++ b/grails-app/conf/application.groovy
@@ -144,3 +144,5 @@ breadcrumbParent = 'https://www.ala.org.au/explore-by-location/,Explore'
 
 habitat.layerID = '918'
 //map.bounds = '[-44, 112, -9, 155]'
+
+showNotesInfoInAccordionPanel: false

--- a/grails-app/views/regions/regions.gsp
+++ b/grails-app/views/regions/regions.gsp
@@ -42,7 +42,11 @@
         </p>
         <div id="accordion">
             <g:each in="${menu}" var="item">
-                <h2><a href="#">${item.label}</a></h2>
+                <h2><a href="#">${item.label}</a>
+                    <g:if test="${grailsApplication.config.getProperty("showNotesInfoInAccordionPanel", Boolean, false) && item.notes?.length() > 0}">
+                        <span class="glyphicon glyphicon glyphicon-info-sign layer-info" aria-hidden="true" data-toggle="tooltip" title="${item.notes}"></span>
+                    </g:if>
+                </h2>
                 <div id="${item.layerName}" layer="${item.label}"><span class="loading">
                     <g:message code="loading"/>
                 </span>
@@ -131,7 +135,10 @@
             },
             useGoogleApi: '${(grailsApplication.config.getProperty('google.apikey')) ? "true": ""}'
         });
-    })
+    });
+
+    $('[data-toggle="tooltip"]').tooltip();
+
 </asset:script>
 </body>
 </html>


### PR DESCRIPTION
This adds a informational icon in each accordion layer title showing the layers notes in a tooltip. See screenshot:

![2021-02-25-14-09-32-screenshot](https://user-images.githubusercontent.com/180085/109158190-55d68a80-7773-11eb-8a80-e7133332a5ab.png)

This is only visible when:
```
showNotesInfoInAccordionPanel = true
```
that is `false` by default.
