### PR TITLE
Fix timelapse chart throwing an error

### DIFF
--- a/grails-app/assets/javascripts/region_page.js
+++ b/grails-app/assets/javascripts/region_page.js
@@ -139,7 +139,7 @@ var region = {
         }
 
         if (timeFacet && !forChart) {
-            params.push("fq=" + timeFacet);
+            params.push("fq=" + encodeURIComponent(timeFacet));
         }
 
         // remove any empty elements

--- a/grails-app/assets/javascripts/region_page.js
+++ b/grails-app/assets/javascripts/region_page.js
@@ -434,7 +434,7 @@ var RegionWidget = function (config) {
             }
             // Update taxonomy chart
             if (taxonomyChart && taxonomyWidget) {
-                taxonomyChart.updateQuery(taxonomyWidget.getQuery() + "&fq=" + region.buildTimeFacet());
+                taxonomyChart.updateQuery(taxonomyWidget.getQuery() + "&fq=" + encodeURIComponent(region.buildTimeFacet()));
             }
         },
 
@@ -692,7 +692,7 @@ var TaxonomyWidget = function (config) {
         taxonomyChartOptions = {
             query: query,
             currentState: currentState,
-            subquery: '&fq=' + region.buildTimeFacet(),
+            subquery: '&fq=' + encodeURIComponent(region.buildTimeFacet()),
             rank: "kingdom",
             width: 550,
             height: 420,

--- a/grails-app/assets/javascripts/regions/charts2.js
+++ b/grails-app/assets/javascripts/regions/charts2.js
@@ -227,18 +227,18 @@ function buildGenericFacetChart(name, data, query, chartsDiv, chartOptions) {
             // the facet query can be overridden for date ranges
             if (name == 'occurrence_year') {
                 if (id.match("^before") == 'before') { // startWith
-                    facetQuery = "occurrence_year:[*%20TO%20" + "1850" + "-01-01T12:00:00Z]";
+                    facetQuery = "occurrence_year:[* TO " + "1850" + "-01-01T12:00:00Z]";
                 }
                 else {
                     var decade = id.substr(0, 4);
                     var dateTo = parseInt(decade) + 10;
-                    facetQuery = "occurrence_year:[" + decade + "-01-01T12:00:00Z%20TO%20" + dateTo + "-01-01T12:00:00Z]";
+                    facetQuery = "occurrence_year:[" + decade + "-01-01T12:00:00Z TO " + dateTo + "-01-01T12:00:00Z]";
                 }
             }
 
             // show the records
             document.location = urlConcat(biocacheWebappUrl, "/occurrences/search?q=") + query +
-                "&fq=" + facetQuery;
+                "&fq=" + encodeURIComponent(facetQuery);
         });
     }
 }

--- a/grails-app/services/au/org/ala/regions/MetadataService.groovy
+++ b/grails-app/services/au/org/ala/regions/MetadataService.groovy
@@ -442,7 +442,7 @@ class MetadataService {
     String buildTimeFacet(String from, String to) {
         from = from.equals(WS_DATE_FROM_DEFAULT) ? "*" : from + WS_DATE_FROM_PREFIX
         to = to.equals(Calendar.getInstance().get(Calendar.YEAR)) ? "*" : to + WS_DATE_TO_PREFIX
-        "occurrence_year:[${from} TO ${to}]"
+        "occurrence_year:" + "[${from} TO ${to}]"
     }
 
     /**


### PR DESCRIPTION
When trying to play the timelapse chart in regions we were getting an error dialog box.
This was caused by the SOLR range query containing unencoded square brackets.
Simply making sure that part of the query is also encoded should fix things.